### PR TITLE
Add libssl-dev, required on current ruby builds for Puma SSL support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
 
 RUN apt-get install -y build-essential
 RUN apt-get install -y git
+RUN apt-get install -y libssl-dev
 
 COPY build_files/app/Gemfile build_files/app/Gemfile.lock /app/
 

--- a/build_files/app/spec/unit/puma/puma_spec.rb
+++ b/build_files/app/spec/unit/puma/puma_spec.rb
@@ -1,0 +1,8 @@
+require './spec/helpers/spec_helper'
+require 'puma'
+
+describe Puma do
+  it 'was compiled with SSL support' do
+    expect(described_class::HAS_SSL).to eq true
+  end
+end


### PR DESCRIPTION
Resolves `Puma compiled without SSL support (RuntimeError)` errors